### PR TITLE
ESP32 support

### DIFF
--- a/examples/VNC_ILI9341/VNC_ILI9341.ino
+++ b/examples/VNC_ILI9341/VNC_ILI9341.ino
@@ -12,7 +12,11 @@
  */
 
 #include <Arduino.h>
+#ifdef ESP8266
 #include <ESP8266WiFi.h>
+#else
+#include <WiFi.h>
+#endif
 #include <SPI.h>
 
 #include <Adafruit_GFX.h>
@@ -26,9 +30,9 @@
 #define TFT_CS      (15)
 #define TFT_RESET   (4)
 // SPI:
-// SCK to 14
-// MISO to 12
-// MOSI to 13
+// SCK to 14 (18 on esp32)
+// MISO to 12 (19 on esp32)
+// MOSI to 13 (23 on esp32)
 
 const char * vnc_ip = "192.168.1.12";
 const uint16_t vnc_port = 5900;

--- a/examples/VNC_ILI9341_touch/VNC_ILI9341_touch.ino
+++ b/examples/VNC_ILI9341_touch/VNC_ILI9341_touch.ino
@@ -13,7 +13,11 @@
  */
 
 #include <Arduino.h>
+#ifdef ESP8266
 #include <ESP8266WiFi.h>
+#else
+#include <WiFi.h>
+#endif
 #include <SPI.h>
 
 #include <Adafruit_GFX.h>
@@ -26,8 +30,9 @@
 
 // ILI9341
 // SPI:
-// SCK to 14
-// MOSI to 13
+// SCK to 14 (18 on esp32)
+// MOSI to 13 (23 on esp32)
+// (MISO not connected (or 19 on esp32)
 // Reset to Reset of the ESP
 #define TFT_DC      (5)
 #define TFT_CS      (15)

--- a/src/VNC.h
+++ b/src/VNC.h
@@ -38,6 +38,8 @@
 #ifdef USE_ARDUINO_TCP
 #ifdef ESP8266
 #include <ESP8266WiFi.h>
+#elif ESP32
+#include <WiFi.h>
 #else
 #include <UIPEthernet.h>
 #ifndef UIPETHERNET_H
@@ -264,6 +266,8 @@ class arduinoVNC {
 
 #ifdef USE_ARDUINO_TCP
 #ifdef ESP8266
+        WiFiClient TCPclient;
+#elif ESP32
         WiFiClient TCPclient;
 #else
 #ifdef UIPETHERNET_H

--- a/src/VNC_ILI9341.cpp
+++ b/src/VNC_ILI9341.cpp
@@ -50,9 +50,13 @@ uint32_t ILI9341VNC::getWidth(void) {
 }
 
 void ILI9341VNC::draw_area(uint32_t x, uint32_t y, uint32_t w, uint32_t h, uint8_t *data) {
+#ifdef ESP32
+    Adafruit_ILI9341::drawRGBBitmap(x, y, (uint16_t*)data, w, h);
+#else
     Adafruit_ILI9341::area_update_start(x, y, w, h);
     Adafruit_ILI9341::area_update_data(data, (w*h));
     Adafruit_ILI9341::area_update_end();
+#endif
 }
 
 
@@ -65,15 +69,28 @@ void ILI9341VNC::copy_rect(uint32_t src_x, uint32_t src_y, uint32_t dest_x, uint
 }
 
 void ILI9341VNC::area_update_start(uint32_t x, uint32_t y, uint32_t w, uint32_t h) {
+#ifndef ESP32
     Adafruit_ILI9341::area_update_start(x, y, w, h);
+#else
+    area_x = x;
+    area_y = y;
+    area_w = w;
+    area_h = h;
+#endif
 }
 
 void ILI9341VNC::area_update_data(char *data, uint32_t pixel){
+#ifndef ESP32
     Adafruit_ILI9341::area_update_data((uint8_t *)data, pixel);
+#else
+    Adafruit_ILI9341::drawRGBBitmap(area_x, area_y, (uint16_t*)data, area_w, area_h);
+#endif
 }
 
 void ILI9341VNC::area_update_end(void){
+#ifndef ESP32
     Adafruit_ILI9341::area_update_end();
+#endif
 }
 
 #endif

--- a/src/VNC_ILI9341.h
+++ b/src/VNC_ILI9341.h
@@ -55,6 +55,9 @@ class ILI9341VNC: public VNCdisplay, public Adafruit_ILI9341 {
         void area_update_data(char *data, uint32_t pixel);
         void area_update_end(void);
 
+    private:
+        uint32_t area_x, area_y, area_w, area_h;
+
 };
 
 #endif

--- a/src/VNC_config.h
+++ b/src/VNC_config.h
@@ -67,7 +67,11 @@
 #endif
 
 /// debugging
+#ifdef ESP32
+#define DEBUG_VNC(...) Serial.printf( __VA_ARGS__ )
+#else
 #define DEBUG_VNC(...) os_printf( __VA_ARGS__ )
+#endif
 
 #define DEBUG_VNC_RAW(...)
 #define DEBUG_VNC_HEXTILE(...)

--- a/src/frameBuffer.cpp
+++ b/src/frameBuffer.cpp
@@ -33,6 +33,13 @@
 #define HEXDUMP_COLS 32
 #endif
 
+/// debugging
+#ifdef ESP32
+#define DEBUG_VNC(...) Serial.printf( __VA_ARGS__ )
+#else
+#define DEBUG_VNC(...) os_printf( __VA_ARGS__ )
+#endif
+
 FrameBuffer::FrameBuffer() {
     w = 0;
     h = 0;
@@ -51,15 +58,15 @@ bool FrameBuffer::begin(uint32_t _w, uint32_t _h) {
     // force Size to be a multible of 32Bit
     uint32_t newSize = ((w * h * 2) + 3) & ~((uint32_t) 0x00000003);
 
-    //os_printf("[FrameBuffer::begin] w: %d h: %d size: %d newSize: %d buffer: 0x%08X Heap: %d\n", w, h, size, newSize, buffer, ESP.getFreeHeap());
+    //DEBUG_VNC("[FrameBuffer::begin] w: %d h: %d size: %d newSize: %d buffer: 0x%08X Heap: %d\n", w, h, size, newSize, buffer, ESP.getFreeHeap());
     //delay(10);
 
     if(buffer) {
         if((size < newSize)) {
-            //os_printf("[FrameBuffer::begin] (size < newSize)  realloc... <--------------------------------------\n");
+            //DEBUG_VNC("[FrameBuffer::begin] (size < newSize)  realloc... <--------------------------------------\n");
             delay(10);
             uint8_t * newbuffer = (uint8_t *) realloc(buffer, newSize);
-            //os_printf("[FrameBuffer::begin] newbuffer: 0x%08X\n", newbuffer);
+            //DEBUG_VNC("[FrameBuffer::begin] newbuffer: 0x%08X\n", newbuffer);
             if(!newbuffer) {
                 freeBuffer();
                 return false;
@@ -76,7 +83,7 @@ bool FrameBuffer::begin(uint32_t _w, uint32_t _h) {
         size = newSize;
         return true;
     } else {
-        os_printf("[FrameBuffer::begin] no buffer: 0x%08X Heap: %d <--------------------------------------\n", (size_t)buffer, ESP.getFreeHeap());
+        DEBUG_VNC("[FrameBuffer::begin] no buffer: 0x%08X Heap: %d <--------------------------------------\n", (size_t)buffer, ESP.getFreeHeap());
         buffer = 0;
         size = 0;
         return false;
@@ -89,28 +96,28 @@ uint8_t * FrameBuffer::getPtr(void) {
 
 void FrameBuffer::freeBuffer(void) {
     if(buffer) {
-        //os_printf("[FrameBuffer::draw_rect] free: 0x%08X\n", buffer);
+        //DEBUG_VNC("[FrameBuffer::draw_rect] free: 0x%08X\n", buffer);
         free(buffer);
         buffer = 0;
         size = 0;
-        //os_printf("[FrameBuffer::draw_rect] free: 0x%08X Done.\n", buffer);
+        //DEBUG_VNC("[FrameBuffer::draw_rect] free: 0x%08X Done.\n", buffer);
     }
 }
 
 void FrameBuffer::draw_rect(uint32_t x, uint32_t y, uint32_t rw, uint32_t rh, uint16_t color) {
     if(!buffer) {
-        //os_printf("[FrameBuffer::draw_rect] buffer == null! <--------------------------------------\n");
+        //DEBUG_VNC("[FrameBuffer::draw_rect] buffer == null! <--------------------------------------\n");
         return;
     }
 
     if((((y + rh) * (x + rw)) * sizeof(color)) > size) {
-        os_printf("[FrameBuffer::draw_rect] out of index!  <--------------------------------------\n");
-        os_printf("[FrameBuffer::draw_rect] w: %d h: %d - x: %d y: %d rw: %d rh: %d color: 0x%04X\n", w, h, x, y, rw, rh, color);
+        DEBUG_VNC("[FrameBuffer::draw_rect] out of index!  <--------------------------------------\n");
+        DEBUG_VNC("[FrameBuffer::draw_rect] w: %d h: %d - x: %d y: %d rw: %d rh: %d color: 0x%04X\n", w, h, x, y, rw, rh, color);
         delay(50);
         return;
     }
 
-      //  os_printf("[FrameBuffer::draw_rect] x: %d y: %d rw: %d rh: %d color: 0x%04X\n", x, y, rw, rh, color);
+      //  DEBUG_VNC("[FrameBuffer::draw_rect] x: %d y: %d rw: %d rh: %d color: 0x%04X\n", x, y, rw, rh, color);
        // delay(10);
 
     uint8_t * ptr = buffer + (((y * w) + x) * sizeof(color));
@@ -120,7 +127,7 @@ void FrameBuffer::draw_rect(uint32_t x, uint32_t y, uint32_t rw, uint32_t rh, ui
     uint8_t colorLow = (color & 0xFF);
     uint8_t colorHigh = ((color >> 8) & 0xFF);
 
-    //os_printf("[FrameBuffer::draw_rect] offset: %d buffer: 0x%08X ptr: 0x%08X color: 0x%02X 0x%02X\n", offset, buffer, ptr, colorLow, colorHigh);
+    //DEBUG_VNC("[FrameBuffer::draw_rect] offset: %d buffer: 0x%08X ptr: 0x%08X color: 0x%02X 0x%02X\n", offset, buffer, ptr, colorLow, colorHigh);
     //delay(10);
 
     while(rh--) {


### PR DESCRIPTION
introduce a few #ifdef to support ESP32.

- os_printf(...) is not available on esp32. we could use ESP_LOGx() macros but these are not available on other platforms, so do a Serial.printf() instead
- the WiFi library is called WiFi.h
- all the area_update_... commands are not available in the Adafruit library i found. so replace them.