### PR TITLE
fix byte order on esp32

### DIFF
--- a/src/VNC.cpp
+++ b/src/VNC.cpp
@@ -103,7 +103,11 @@ void arduinoVNC::begin(char *_host, uint16_t _port, bool _onlyFullUpdate) {
     opt.client.bpp = 16;
     opt.client.depth = 16;
 
+#ifdef ESP32
+    opt.client.bigendian = 0;
+#else
     opt.client.bigendian = 1;
+#endif
     opt.client.truecolour = 1;
 
     opt.client.redmax = 31;


### PR DESCRIPTION
sorry, i missed that at the previous pull request. the esp is little-endian.

also i believe bug #12 can be marked as fixed now.